### PR TITLE
Set up Twitter hashtag data route

### DIFF
--- a/server/routes/twitter.js
+++ b/server/routes/twitter.js
@@ -1,0 +1,47 @@
+require('dotenv').config({ path: '../.env' });
+const router = require('express').Router();
+const axios = require('axios');
+
+router.get('/hashtag-data', async (req, res) => {
+  const options = {
+    method: 'GET',
+    url: `https://api.twitter.com/2/users/20702956/tweets?tweet.fields=created_at,entities,public_metrics&max_results=50`,
+    headers: {
+      'Authorization': `Bearer ${process.env.BEARER_TOKEN}`
+    }
+  }
+
+  try {
+    const results = await axios(options);
+
+    res.status(200).end(JSON.stringify(analyzeHashtags(results.data.data)))
+  } catch {
+
+    (err) => res.status(404).end('There was an error fetching Twitter data:', err)
+  }
+})
+
+var analyzeHashtags = function (data) {
+  var analytics = {};
+
+  for (var i = 0; i < data.length; i++) {
+    var hashtags = data[i].entities ? data[i].entities.hashtags || [] : [];
+    for (var j = 0; j < hashtags.length; j++) {
+      var hashtag = hashtags[j].tag;
+      if (analytics[hashtag]) {
+        analytics[hashtag].retweets += data[i].public_metrics.retweet_count;
+        analytics[hashtag].replies += data[i].public_metrics.reply_count;
+        analytics[hashtag].likes += data[i].public_metrics.like_count;
+      } else {
+        analytics[hashtag] = {};
+        analytics[hashtag].retweets = data[i].public_metrics.retweet_count;
+        analytics[hashtag].replies = data[i].public_metrics.reply_count;
+        analytics[hashtag].likes = data[i].public_metrics.like_count;
+      }
+    }
+  }
+
+  return analytics;
+}
+
+module.exports = router;

--- a/server/routes/twitter.js
+++ b/server/routes/twitter.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 router.get('/hashtag-data', async (req, res) => {
   const options = {
     method: 'GET',
-    url: `https://api.twitter.com/2/users/${req.user_id}/tweets?tweet.fields=created_at,entities,public_metrics&max_results=${req.max_results}`,
+    url: `https://api.twitter.com/2/users/${req.body.user_id}/tweets?tweet.fields=created_at,entities,public_metrics&max_results=${req.body.max_results}`,
     headers: {
       'Authorization': `Bearer ${process.env.BEARER_TOKEN}`
     }

--- a/server/routes/twitter.js
+++ b/server/routes/twitter.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 router.get('/hashtag-data', async (req, res) => {
   const options = {
     method: 'GET',
-    url: `https://api.twitter.com/2/users/20702956/tweets?tweet.fields=created_at,entities,public_metrics&max_results=50`,
+    url: `https://api.twitter.com/2/users/${req.user_id}/tweets?tweet.fields=created_at,entities,public_metrics&max_results=${req.max_results}`,
     headers: {
       'Authorization': `Bearer ${process.env.BEARER_TOKEN}`
     }


### PR DESCRIPTION
Created /twitter/hashtag-data route to provide aggregate information on tweet performance based on hashtags used.

Note that this route does not require Twitter authentication, and the token I'm using for it won't expire.

Trello: https://trello.com/c/ABTypsn1/13-must-have-provide-aggregate-users-own-content-data-from-twitter